### PR TITLE
Remove cont marker from sub map retrievals

### DIFF
--- a/src/eightbdkbd/client.py
+++ b/src/eightbdkbd/client.py
@@ -67,7 +67,7 @@ class EightBDKdb:
         keymap = bytes() + r[2:-1]  # last byte is a marker
         while r[-1] == 0x01:  # indicates there are more maps
             r = self.read_check_start(PROFILE_MAPPED)
-            keymap += r[2:]
+            keymap += r[2:-1]
 
         mapped_keys = []
         for i, kc in enumerate(keymap):


### PR DESCRIPTION
Failing to remove the continue marker from subsequent calls to retrieve the mapping list, results in the delimiter being repeatedly shown as a mapping for later results ( see #4 ). This PR addresses this issue, removing the delimiter from those subsequent results.

Before:

```
Mapped keys: b c d e f g h i j k l n o p q r s t u v w x y z minus equal leftbrace rightbrace semicolon apostrophe d d d d
...
```

After:

```
Mapped keys: b c d e f g h i j k l n o p q r s t u v w x y z minus equal leftbrace rightbrace semicolon apostrophe comma dot slash capslock
...
```

Fixes #4.