### PR TITLE
Add Nix flake with package, NixOS module, and dev shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ pcaps
 *.pdf
 *.sh
 tmp*
+
+# Nix / direnv
+result
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774701658,
+        "narHash": "sha256-CIS/4AMUSwUyC8X5g+5JsMRvIUL3YUfewe8K4VrbsSQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b63fe7f000adcfa269967eeff72c64cafecbbebe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -11,10 +11,7 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
 
-        version =
-          if self ? rev
-          then self.shortRev
-          else "dirty";
+        version = "0.0.0+${self.shortRev or "dirty"}";
 
         patchUdevRules = rulesFile:
           pkgs.runCommand (builtins.baseNameOf rulesFile) { } ''

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,93 @@
+{
+  description = "Key mapper for 8BitDo Retro Mechanical Keyboards";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        version =
+          if self ? rev
+          then self.shortRev
+          else "dirty";
+
+        patchUdevRules = rulesFile:
+          pkgs.runCommand (builtins.baseNameOf rulesFile) { } ''
+            substitute ${rulesFile} $out \
+              --replace-fail '/usr/bin/sh' '${pkgs.bash}/bin/sh'
+          '';
+
+        eightbdkbd = pkgs.python3Packages.buildPythonApplication {
+          pname = "8bdkbd";
+          inherit version;
+          pyproject = true;
+
+          src = self;
+
+          env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+          build-system = with pkgs.python3Packages; [
+            setuptools
+            setuptools-scm
+          ];
+
+          dependencies = with pkgs.python3Packages; [
+            pyusb
+          ];
+
+          # pyusb needs libusb1 at runtime
+          makeWrapperArgs = [
+            "--prefix" "LD_LIBRARY_PATH" ":" "${pkgs.lib.makeLibraryPath [ pkgs.libusb1 ]}"
+          ];
+
+          postInstall = ''
+            install -Dm644 ${patchUdevRules ./50-8bitdo-kdb.rules} \
+              $out/etc/udev/rules.d/50-8bitdo-kdb.rules
+            install -Dm644 ${patchUdevRules ./50-8bitdo-108-key-kdb.rules} \
+              $out/etc/udev/rules.d/50-8bitdo-108-key-kdb.rules
+          '';
+
+          meta = with pkgs.lib; {
+            description = "Key mapper for 8BitDo's Retro Mechanical Keyboard";
+            homepage = "https://github.com/goncalor/8bitdo-kbd-mapper/";
+            license = licenses.gpl3Only;
+            mainProgram = "8bdkbd";
+          };
+        };
+      in
+      {
+        packages.default = eightbdkbd;
+
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            python3
+            python3Packages.pyusb
+            libusb1
+          ];
+
+          env.LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [ pkgs.libusb1 ];
+        };
+      }
+    ) // {
+      nixosModules.default = { config, lib, pkgs, ... }:
+        let
+          cfg = config.programs.eightbdkbd;
+          pkg = self.packages.${pkgs.system}.default;
+        in
+        {
+          options.programs.eightbdkbd = {
+            enable = lib.mkEnableOption "8BitDo Retro Mechanical Keyboard key mapper";
+          };
+
+          config = lib.mkIf cfg.enable {
+            environment.systemPackages = [ pkg ];
+            services.udev.packages = [ pkg ];
+          };
+        };
+    };
+}


### PR DESCRIPTION
## Summary
- Add `flake.nix` with `packages.default` (builds with `buildPythonApplication`), `nixosModules.default` (installs package + udev rules), and `devShells.default`
- Udev rules are patched to use Nix store path for `sh` instead of `/usr/bin/sh`
- Add `.envrc` for direnv integration and update `.gitignore` for Nix artifacts
- Add Nix installation instructions to README (standalone usage and NixOS module)